### PR TITLE
Retouch for nextcloud the addressbooks line

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -176,8 +176,8 @@ elif yunohost app list --installed -f nextcloud | grep -q id ; then
 	ynh_replace_string --match_string="__CALDAV_PERSONAL__" --replace_string="personal" --target_file="../conf/backend/config-caldav.php"
 
 	ynh_replace_string --match_string="__CARDDAV_SERVER__" --replace_string="${nextclouddomain}" --target_file="../conf/backend/config-carddav.php"
-	ynh_replace_string --match_string="__CARDDAV_PATH__" --replace_string="${nextcloudpath}/remote.php/dav/addressbooks/users/%u/contacts/" --target_file="../conf/backend/config-carddav.php"
-	ynh_replace_string --match_string="__CARDDAV_DEFAULT_PATH__" --replace_string="${nextcloudpath}/remote.php/dav/addressbooks/users/%u/contacts/" --target_file="../conf/backend/config-carddav.php"
+	ynh_replace_string --match_string="__CARDDAV_PATH__" --replace_string="${nextcloudpath}/remote.php/dav/addressbooks/users/%u/" --target_file="../conf/backend/config-carddav.php"
+	ynh_replace_string --match_string="__CARDDAV_DEFAULT_PATH__" --replace_string="${nextcloudpath}/remote.php/dav/addressbooks/users/%u/" --target_file="../conf/backend/config-carddav.php"
 
 	ynh_replace_string --match_string="__IMAP_SERVER__" --replace_string="${domain}" --target_file="../conf/backend/config-imap.php"
 	ynh_replace_string --match_string="__FLAGTOCHANGE__" --replace_string="true" --target_file="../conf/backend/config-imap.php"


### PR DESCRIPTION
just remove the "/contacts" indication... and works perfectly...

## Problem
Error working with nextcloud 404 so it do not start correctly

## Solution
- Just remove in cardav config file the statement "/contacts" and end the line with just "%u/"
- Fixes #57 

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR-NUM-%20(USERNAME)/)  
