### PR TITLE
include the fail2ban feature not included before

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -217,6 +217,13 @@ ynh_print_info --message="Securing files and directories..."
 
 # Set permissions to app files
 chown -R $app: $final_path
+##add jail2ban file
+echo "[z-push] " > /etc/fail2ban/jail.d/z-push.conf
+echo "enable = true" >> /etc/fail2ban/jail.d/z-push.conf
+echo "port = http, https" >> /etc/fail2ban/jail.d/z-push.conf
+echo "filter = z-push " >> /etc/fail2ban/jail.d/z-push.conf
+echo "logpath = /var/log/z-push/z-push-error.log" >> /etc/fail2ban/jail.d/z-push.conf
+## that easy
 
 #=================================================
 # SETUP LOGROTATE


### PR DESCRIPTION
Need to relaunch fail2ban, but adding this will work. Checked more than twice...

## Problem
 no fail2ban data or use

## Solution
a couple of lines with echo... and done

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR-NUM-%20(USERNAME)/)  
