### PR TITLE
[N.B. : App to be downgraded to level 4 if this ain't fixed soon...] Update nginx.conf to protect against path traversal issue

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,5 @@
-location /Microsoft-Server-ActiveSync {
+#sub_path_only rewrite ^Microsoft-Server-ActiveSync$ Microsoft-Server-ActiveSync/ permanent; 
+location /Microsoft-Server-ActiveSync/ {
   # Path to source
   alias __FINALPATH__/ ;
 


### PR DESCRIPTION
c.f upcoming change in package_linter that will trigger a "real" error (instead of warning previously) for path traversal issues

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR61%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/z-push_ynh%20PR61%20(yalh76)/)  