### PR TITLE
Fix permissions on DATA_DIR

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -49,6 +49,13 @@ chown -R $app:www-data "/var/log/$app/"
 ynh_use_logrotate
 
 #=================================================
+# CREATE DATA DIRECTORY
+#=================================================
+ynh_script_progression "Setting permissions for the data directory..."
+
+chown -R $app:$app "$data_dir"
+
+#=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression --message="Adding a configuration file..."

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,7 +27,7 @@ ynh_script_progression --message="Restoring the data directory..." --weight=1
 
 ynh_restore_file --origin_path="$data_dir" --not_mandatory
 
-chown -R $app:www-data "$data_dir"
+chown -R $app:$app "$data_dir"
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION


### PR DESCRIPTION
When reinstalling, the folder can belong to the old UID/GID of the old user.

It also fixes a small issue that when integrating Z-Push with baikal, Z-Push fails to authenticate because STATE_DIR isn't writable (``settings`` and ``users`` files on DATA_DIR: /home/yunohost.app/z-push/).

It also removes the ``www-data`` group access to DATA_DIR since only the webuser needs to access it.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
