### PR TITLE
Fix Authentication on Outlook 365

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,12 @@
+location = / {
+  rewrite ^ /Microsoft-Server-ActiveSync/ permanent;
+}
+  
 #sub_path_only rewrite ^Microsoft-Server-ActiveSync$ Microsoft-Server-ActiveSync/ permanent; 
-rewrite ^/$ Microsoft-Server-ActiveSync/ permanent; 
-location /Microsoft-Server-ActiveSync/ {
+#rewrite ^/$ Microsoft-Server-ActiveSync/ permanent; 
+#location /Microsoft-Server-ActiveSync/ {
+rewrite ^/Microsoft-Server-ActiveSync$ /Microsoft-Server-ActiveSync/ permanent;
+location ^~ /Microsoft-Server-ActiveSync/ {
 
   # Path to source
   alias __INSTALL_DIR__/;


### PR DESCRIPTION
Fix redirect to work on Outlook 365 based on @gaston78125 at https://github.com/YunoHost-Apps/z-push_ynh/issues/67

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
